### PR TITLE
chore: drop support for node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ notifications:
   email: false
 node_js:
   - node
+  - lts/carbon
   - lts/boron
-  - lts/argon

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/simonkberg/eslint-config-react#readme",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
BREAKING CHANGE: Only node 6+ is actively supported and tested.